### PR TITLE
chore: add post deploy checks

### DIFF
--- a/repo-lookup.json
+++ b/repo-lookup.json
@@ -1,97 +1,85 @@
 {
-  "assessmentregistry8-site": {
-    "elk_name": "assessments",
-    "stack_name": "assessmentregistry-stack",
-    "jenkins_name": "Assessments",
-    "jenkins_other_name": "assessments"
-  },
   "cerf8": {
     "elk_name": "cerf",
     "stack_name": "cerf-stack",
+    "prod_url": "cerf.un.org",
     "jenkins_name": "CERF",
     "jenkins_other_name": "cerf"
   },
   "common-design-site": {
     "elk_name": "commondesign",
     "stack_name": "common-design-stack",
+    "prod_url": "web.brand.un.org",
     "jenkins_name": "Common Design",
     "jenkins_other_name": "ds-commondesign"
-  },
-  "docstore-site": {
-    "elk_name": "docstore",
-    "stack_name": "docstore-stack",
-    "jenkins_name": "Docstore",
-    "jenkins_other_name": "docstore"
   },
   "drupal-starterkit": {
     "elk_name": "n/a",
     "stack_name": "n/a",
+    "prod_url": "n/a",
     "jenkins_name": "n/a",
     "jenkins_other_name": "n/a"
   },
   "gms-site": {
     "elk_name": "gms",
     "stack_name": "gms-stack",
+    "prod_url": "gms.unocha.org",
     "jenkins_name": "GMS",
     "jenkins_other_name": "gms"
-  },
-  "hrinfo-site": {
-    "elk_name": "hrinfo",
-    "stack_name": "hrinfo-stack",
-    "jenkins_name": "HR.info",
-    "jenkins_other_name": "hrinfo"
   },
   "iasc8": {
     "elk_name": "iasc",
     "stack_name": "iasc-stack",
+    "prod_url": "interagencystandingcommittee.org",
     "jenkins_name": "IASC",
     "jenkins_other_name": "iasc"
-  },
-  "numbers-site": {
-    "elk_name": "numbers",
-    "stack_name": "numbers-stack",
-    "jenkins_name": "Numbers",
-    "jenkins_other_name": "numbers"
   },
   "odsg8-site": {
     "elk_name": "odsg",
     "stack_name": "odsg-stack",
+    "prod_url": "odsg.unocha.org",
     "jenkins_name": "ODSG",
     "jenkins_other_name": "odsg"
   },
   "response-site": {
     "elk_name": "response",
     "stack_name": "response-stack",
+    "prod_url": "response.reliefweb.int",
     "jenkins_name": "Response",
     "jenkins_other_name": "response"
   },
   "rwint9-site": {
     "elk_name": "rwint",
     "stack_name": "rwint-stack",
+    "prod_url": "reliefweb.int",
     "jenkins_name": "ReliefWeb",
     "jenkins_other_name": "rwint-site"
   },
   "slt8-site": {
     "elk_name": "slt",
     "stack_name": "slt-stack",
+    "prod_url": "savinglivestogether.unocha.org",
     "jenkins_name": "SLT",
     "jenkins_other_name": "slt"
   },
   "sesame-site": {
     "elk_name": "sesame",
     "stack_name": "sesame-stack",
+    "prod_url": "auth.ahconu.org",
     "jenkins_name": "Sesame",
     "jenkins_other_name": "sesame"
   },
   "unocha-site": {
     "elk_name": "unocha",
     "stack_name": "unocha-stack",
+    "prod_url": "unocha.org",
     "jenkins_name": "UN-OCHA D10",
     "jenkins_other_name": "unocha"
   },
   "whd-2023-site": {
     "elk_name": "whd",
     "stack_name": "whd-stack",
+    "prod_url": "worldhumanitarianday.org",
     "jenkins_name": "WHD",
     "jenkins_other_name": "whd"
   }


### PR DESCRIPTION
CERF-290: Checks for the 'GTM-' string in the homepage for each property after each production deploy.
CERF-251: Checks a single pdf after deploying CERF. And adds space for similar site-specific checks.