### PR TITLE
docs: re-organize scripts to reflect current usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,7 @@ JENKINS_URL="jenkins_url"
 
 # These are secrets..
 BASIC_AUTH_CREDENTIALS="user:pass"
+# Found by clicking your username from ‘jenkins.aws.ahconu.org’ (when logged in).
 JENKINS_ID="jenkins_id"
 # Needs generating at JENKINS_URL/user/JENKINS_ID/configure
 JENKINS_TOKEN="jenkins_token"

--- a/README.md
+++ b/README.md
@@ -1,55 +1,49 @@
-# Helpful maintenance scripts
+# Drupal maintenance scripts
 
-A group of helpful scripts for automating common maintenance tasks.
+A group of scripts for automating common maintenance tasks for drupal repos.
 Inspired by [this blogpost.](https://blog.danslimmon.com/2019/07/15/do-nothing-scripting-the-key-to-gradual-automation/)
 
-The initial focus was on updating core or specific contrib modules for all the
-repos, before periodic updates were automated in github actions.
+There are four separate scripts:
 
-It's now more useful for following the steps of a deployment process, modifying
-a few sites at once, and running audits.
+* `common_changes.sh` For making the same change to more than one repo.
+
+* `deployment_steps.sh` Test, prep and complete deployments.
+** 1. test with vrt - comparison of prod and dev
+** 2. send communications, update Jira tickets
+** 3. merge to main
+** 4. create tags
+** 5. stage deploy
+** 6. send more communications
+** 7. prod deploy - including post-deployment tests
+
+* `module_audit.sh` Produce a csv of all drupal and unocha modules used.
+
+* `reset_branches.sh` A helper for the module audit script - checkout and update
+develop and main branches and install dependencies for each repo.
 
 ## Requirements
-Most requirements - docker, composer, git, curl should already be in place.
+Jenkins ID and API token, defined in `.env` file, to kick off vrt jobs.
+See https://www.jenkins.io/blog/2018/07/02/new-api-token-system/
+
+Most, e.g. docker, composer, git, curl, should already be in place.
+
+The deploy script requires `jq`
+on Ubuntu `sudo apt install jq`
+for others: https://jqlang.github.io/jq/download/
+
 The module audit script requires `libxml2-utils`:
 on Ubuntu `sudo apt install libxml2-utils`
 
-## List of scripts:
+## Configuration files
 
-* common.sh
-Common functions used by one or more of the scripts here.
+* `.env`
+Common urls and secrets. Copy `.env.example` and set all the values.
 
-* drupal_updates.sh
-A lightly automated checklist to step through multiple drupal repos. Used for
-making repetitive changes or preparing and performing deployments.
-
-* module_audit.sh
-Generates csv files listing all modules and which repos they're used in,
-and similar for outdated modules.
-
-* reset_branches.sh
-Update main and develop branches for each repo, running composer install to
-bring packages up-to-date.
-
-## List of configuration files:
-
-* repolist.txt
+* `repolist.txt`
 A list of repos to run the scripts on. These often change depending on the job.
 
-* repo-lookup.json
-A dictionary to match repo names (for jenkins, elk, the stack and the prod url).
-
-## Stages of drupal_updates.sh script.
-For making changes to more than one repo:
-1. create PR
-Deployment steps:
-2. test with vrt - comparison of prod and stage
-3. send communications
-4. merge to main
-5. create tags
-6. deploy tag to stage
-7. send more communications
-8. prod deploy - including post-deployment tests
+* `repo-lookup.json`
+A dictionary to match repo names to e.g. jenkins names, elk name, and prod url.
 
 ## Post deployment tests
 * GTM (see `check_gtm` function in `common.sh`).
@@ -61,6 +55,7 @@ to see if it returns a pdf.
 
 ## TODO
 * Adapt 'open' and 'copy' commands for macOS, and windows.
+* Complete movement of uses of vrt from local to Jenkins.
 
 ## Assumptions:
 * all the repositories are in the same parent directory

--- a/README.md
+++ b/README.md
@@ -7,14 +7,7 @@ There are four separate scripts:
 
 * `common_changes.sh` For making the same change to more than one repo.
 
-* `deployment_steps.sh` Test, prep and complete deployments.
-** 1. test with vrt - comparison of prod and dev
-** 2. send communications, update Jira tickets
-** 3. merge to main
-** 4. create tags
-** 5. stage deploy
-** 6. send more communications
-** 7. prod deploy - including post-deployment tests
+* `deployment_steps.sh` Test, prep and complete deployments. See steps below.
 
 * `module_audit.sh` Produce a csv of all drupal and unocha modules used.
 
@@ -25,7 +18,7 @@ develop and main branches and install dependencies for each repo.
 Jenkins ID and API token, defined in `.env` file, to kick off vrt jobs.
 See https://www.jenkins.io/blog/2018/07/02/new-api-token-system/
 
-Most, e.g. docker, composer, git, curl, should already be in place.
+Most other requirements: docker, composer, git, curl, etc. will already exist.
 
 The deploy script requires `jq`
 on Ubuntu `sudo apt install jq`
@@ -44,6 +37,15 @@ A list of repos to run the scripts on. These often change depending on the job.
 
 * `repo-lookup.json`
 A dictionary to match repo names to e.g. jenkins names, elk name, and prod url.
+
+## Deployment steps
+1. test with vrt - comparison of prod and dev
+1. send communications, update Jira tickets
+1. merge to main
+1. create tags
+1. stage deploy
+1. send more communications
+1. prod deploy - including post-deployment tests
 
 ## Post deployment tests
 * GTM (see `check_gtm` function in `common.sh`).

--- a/common.sh
+++ b/common.sh
@@ -7,11 +7,11 @@
 
 set -eux
 
-requires () {
-    if ! command -v "$1" &>/dev/null; then
-        echo "Requires $1"
-        exit 1
-    fi
+requires() {
+  if ! command -v "$1" &>/dev/null; then
+    echo "Requires $1"
+    exit 1
+  fi
 }
 
 requires "composer"
@@ -28,35 +28,35 @@ jenkins_url=$JENKINS_URL
 # Get repolist from repolist.txt
 repolist=()
 echo "List of repos to reset:"
-while IFS= read -r -u 3 repo ; do
+while IFS= read -r -u 3 repo; do
   # Skip blank lines and commented lines.
-  case "$repo" in ''|\#*) continue ;; esac
+  case "$repo" in '' | \#*) continue ;; esac
   echo "$repo"
   repolist+=("$repo")
-done 3< repolist.txt
+done 3<repolist.txt
 
 # To allow checking output, or when something needs doing that hasn't yet been
 # automated.
-wait_to_continue () {
+wait_to_continue() {
   read -r -p "Hit enter when you're ready to continue" _
 }
 
 # Open url.
 # TODO: get this working for MacOS etc, and to give a warning if it fails.
-open_url () {
-  ( command -v xdg-open >/dev/null 2>&1 ) &&
+open_url() {
+  (command -v xdg-open >/dev/null 2>&1) &&
     xdg-open "$1"
 }
 
 # Copy to both the selection buffer and clipboard with xclip.
 # TODO: get this working for MacOS etc, and to give a warning if it fails.
-copy_to_clipboard () {
-  ( command -v xclip >/dev/null 2>&1 ) &&
+copy_to_clipboard() {
+  (command -v xclip >/dev/null 2>&1) &&
     echo "$1" | xclip -i -sel c -f | xclip -i -sel p
 }
 
-update_branches () {
-  branches=( "main" "develop" )
+update_branches() {
+  branches=("main" "develop")
   for branch in "${branches[@]}"; do
     echo "Updating $branch branch for $repo"
     if ! git checkout "$branch"; then
@@ -65,7 +65,7 @@ update_branches () {
       echo "Fix the unmerged changes for ${repo} and try this step again"
       return 1
     fi
-    if ! git pull; then 
+    if ! git pull; then
       echo $?
       echo "- - -"
       echo "Fix the unmerged changes for ${repo} and try this step again"
@@ -77,7 +77,7 @@ update_branches () {
   echo "Develop and main branches for $repo updated"
 }
 
-need_a_feature_branch () {
+need_a_feature_branch() {
   echo "checking feature branch for $repo"
   diff_output=$(git diff main --name-status)
   diff_length=$(wc -l <<<"$diff_output" | cut -d" " -f1)
@@ -102,21 +102,23 @@ need_a_feature_branch () {
   options=("yes" "no")
   select feature_branch in "${options[@]}"; do
     case $feature_branch in
-      "yes")
-        echo "setting feature branch for $repo"
-        branch_name="feature/${branch_name}"
-        echo "checking out main branch to create feature from"
-        git checkout main
-        break;;
-      "no")
-        echo "continuing"
-        break;;
-      *) echo "invalid option ${REPLY}. Please enter '1' for yes, '2' for no."
+    "yes")
+      echo "setting feature branch for $repo"
+      branch_name="feature/${branch_name}"
+      echo "checking out main branch to create feature from"
+      git checkout main
+      break
+      ;;
+    "no")
+      echo "continuing"
+      break
+      ;;
+    *) echo "invalid option ${REPLY}. Please enter '1' for yes, '2' for no." ;;
     esac
   done
 }
 
-set_new_branch () {
+set_new_branch() {
   echo "- - -"
   echo "- - -"
   echo "creating new branch in $repo"
@@ -124,7 +126,7 @@ set_new_branch () {
 
 }
 
-check_and_add_changes () {
+check_and_add_changes() {
   echo "- - -"
   echo "- - -"
   echo "In another tab/ window, 'cd ${full_path}/${repo}', make any changes necessary and 'git add' them to the ${branch_name} branch of ${repo}"
@@ -136,7 +138,7 @@ check_and_add_changes () {
 
 }
 
-commit_changes () {
+commit_changes() {
   echo "- - -"
   echo "- - -"
   echo "confirm everything is ready to commit"
@@ -153,7 +155,7 @@ commit_changes () {
 
 }
 
-push_changes () {
+push_changes() {
   echo "- - -"
   echo "- - -"
   echo "pushing to $repo remote"
@@ -168,7 +170,7 @@ push_changes () {
 
 }
 
-check_gtm () {
+check_gtm() {
   home="$1"
   echo "$home"
   echo "Checking for presence of GTM:"
@@ -176,23 +178,21 @@ check_gtm () {
   wait_to_continue
 }
 
-check_extra () {
+check_extra() {
   repo="$1"
-  if [[ $repo = "cerf8" ]]
-  then
+  if [[ $repo = "cerf8" ]]; then
     echo "Checking PDF works for CERF"
     test_page="https://cerf.un.org/what-we-do/allocation-pdf/2021/summary/21-RR-COL-49434"
     curl -L -s "$test_page" | grep -iF "%%EOF" || echo "Didn't get a PDF returned. Check this!"
     wait_to_continue
-  elif [[ $repo = "other" ]]
-  then
+  elif [[ $repo = "other" ]]; then
     echo "additional checks here"
   else
     echo "No checks for $repo"
   fi
 }
 
-run_vrt () {
+run_vrt() {
   repo="$1"
   stage="$2"
   environment="$3"
@@ -205,8 +205,8 @@ run_vrt () {
 
     # TODO revise VRT logins so it works with authenticated users too.
     # statuses=( 'anon' 'auth' )
-    statuses=( 'anon' )
-    for status in "${statuses[@]}" ; do
+    statuses=('anon')
+    for status in "${statuses[@]}"; do
       docker run -u "$(id -u)" --shm-size 512m --rm --name "${stage}" --net="host" --entrypoint npm -e REPO="${repo}" -e LOGGED_IN_STATUS="${status}" -e ENVIRONMENT="${environment}" -v "$(pwd):/srv" -v "$(pwd)/data/${repo}:/srv/data" -v "$(pwd)/config:/srv/config" -w /srv public.ecr.aws/unocha/vrt:local run "${stage}"
     done
 
@@ -214,15 +214,15 @@ run_vrt () {
   fi
 }
 
-vrt_report () {
+vrt_report() {
   repo="$1"
 
   cd ../tools-vrt || exit
 
   # TODO revise VRT logins so it works with authenticated users too.
   # statuses=( 'anon' 'auth' )
-  statuses=( 'anon' )
-  for status in "${statuses[@]}" ; do
+  statuses=('anon')
+  for status in "${statuses[@]}"; do
     file="file://$(pwd)/data/${repo}/${status}/html_report/index.html"
     echo "Opening $file in browser"
     open_url "$file"
@@ -231,14 +231,14 @@ vrt_report () {
   cd - || exit
 
   # Match repo name to elk name.
-  elk_name=$(jq -r '."'"$repo"'".elk_name' < ./repo-lookup.json)
+  elk_name=$(jq -r '."'"$repo"'".elk_name' <./repo-lookup.json)
   echo "Opening ELK report for $elk_name"
 
   log_url="https://elk.aws.ahconu.org/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15m,to:now))&_a=(columns:!(unocha.property,drupal.action,drupal.message,drupal.request_uri,syslog.severity_label,unocha.environment),filters:!(('\$state':(store:appState),meta:(alias:!n,disabled:!f,index:'69b486f0-81d4-11ea-9a40-e9f42857bb64',key:unocha.property,negate:!f,params:!(${elk_name}),type:phrases),query:(bool:(minimum_should_match:1,should:!((match_phrase:(unocha.property:${elk_name})))))),('\$state':(store:appState),meta:(alias:!n,disabled:!f,index:'69b486f0-81d4-11ea-9a40-e9f42857bb64',key:syslog.severity_label,negate:!t,params:(query:informational),type:phrase),query:(match_phrase:(syslog.severity_label:informational))),('\$state':(store:appState),meta:(alias:!n,disabled:!f,index:'69b486f0-81d4-11ea-9a40-e9f42857bb64',key:syslog.severity_label,negate:!t,params:(query:debug),type:phrase),query:(match_phrase:(syslog.severity_label:debug))),('\$state':(store:appState),meta:(alias:!n,disabled:!f,index:'69b486f0-81d4-11ea-9a40-e9f42857bb64',key:syslog.severity_label,negate:!t,params:(query:notice),type:phrase),query:(match_phrase:(syslog.severity_label:notice))),('\$state':(store:appState),meta:(alias:!n,disabled:!f,index:'69b486f0-81d4-11ea-9a40-e9f42857bb64',key:syslog.severity_label,negate:!t,params:(query:notice),type:phrase),query:(match_phrase:(syslog.severity_label:warning))),('\$state':(store:appState),meta:(alias:!n,disabled:!f,index:'69b486f0-81d4-11ea-9a40-e9f42857bb64',key:drupal.action,negate:!t,params:(query:'access%20denied'),type:phrase),query:(match_phrase:(drupal.action:'access%20denied'))),('\$state':(store:appState),meta:(alias:!n,disabled:!f,index:'69b486f0-81d4-11ea-9a40-e9f42857bb64',key:drupal.action,negate:!t,params:(query:user_expire),type:phrase),query:(match_phrase:(drupal.action:user_expire)))),index:'69b486f0-81d4-11ea-9a40-e9f42857bb64',interval:auto,query:(language:kuery,query:''),sort:!(!('@timestamp',desc)))"
   open_url "$log_url"
 }
 
-create_pr () {
+create_pr() {
   ticket_number="$1"
 
   echo "Enter branch name (without the ticket number):"
@@ -247,7 +247,7 @@ create_pr () {
 
   read -r -p "Enter a one-line commit message, including the standard commit type (without the ticket number):" commit_message
 
-  for repo in "${repolist[@]}" ; do
+  for repo in "${repolist[@]}"; do
 
     echo "* * *"
     echo "Processing repo $repo"
@@ -256,9 +256,9 @@ create_pr () {
     echo "cd-ing to the $repo repo"
     cd "${full_path}/${repo}" || exit
 
-    update_branches || (echo "Failed to update branches due to a merge conflict. In another tab/ window, 'cd ${full_path}/${repo}', and manually update the develop and main branches." && \
-    copy_to_clipboard "cd ${full_path}/${repo}" && \
-    echo "CD command: 'cd ${full_path}/${repo}' copied to clipboard")
+    update_branches || (echo "Failed to update branches due to a merge conflict. In another tab/ window, 'cd ${full_path}/${repo}', and manually update the develop and main branches." &&
+      copy_to_clipboard "cd ${full_path}/${repo}" &&
+      echo "CD command: 'cd ${full_path}/${repo}' copied to clipboard")
     wait_to_continue
 
     need_a_feature_branch
@@ -280,32 +280,30 @@ create_pr () {
 
 }
 
-dev_communications () {
+dev_communications() {
   echo "Check https://docs.google.com/spreadsheets/d/1db2o3SG52uPG0SlbNuj9YyIvnqSPmCND9wQaaaC0i1Y/edit#gid=0 for communication steps"
 }
 
-vrt_comparison () {
-  echo "This uses vrt to open some links on the dev sites and compare them to" 
+vrt_comparison() {
+  echo "This uses vrt to open some links on the dev sites and compare them to"
   echo "the same links on the production site."
 
   # Check we have a Jenkins API token.
-  if [[ $JENKINS_TOKEN = '' ]]
-  then
+  if [[ $JENKINS_TOKEN = '' ]]; then
     echo "A Jenkins API token is needed and should be defined in the .env file."
     echo "See https://www.jenkins.io/blog/2018/07/02/new-api-token-system/"
   else
     results=("https://jenkins.aws.ahconu.org/view/VRT/job/vrt-anonymous/")
-    for repo in "${repolist[@]}" ; do
+    for repo in "${repolist[@]}"; do
 
-      if [[ $repo = "docstore-site" ]]
-      then
+      if [[ $repo = "docstore-site" ]]; then
         continue
       fi
 
       # Match repo to other names.
-      prod_url=$(jq -r '."'"$repo"'".prod_url' < ./repo-lookup.json)
+      prod_url=$(jq -r '."'"$repo"'".prod_url' <./repo-lookup.json)
       prod_url="https://$prod_url"
-      stage_url=$(jq -r '."'"$repo"'".stage_url' < ./repo-lookup.json)
+      stage_url=$(jq -r '."'"$repo"'".stage_url' <./repo-lookup.json)
       stage_url="https://$BASIC_AUTH_CREDENTIALS@$stage_url"
 
       echo "Kicking off jenkins vrt job for $repo."
@@ -313,7 +311,7 @@ vrt_comparison () {
 
       last_build_url=$(curl -X POST --user ${JENKINS_ID}:${JENKINS_TOKEN} "${jenkins_url}/view/VRT/job/vrt-anonymous/api/json" | jq ".lastBuild.url" | tr '"' '')
       results+=("${last_build_url}artifact/data/anon/html_report/index.html")
-    done;
+    done
   fi
 
   echo "Opening jenkins vrt output to check results of VRT jobs."
@@ -325,17 +323,17 @@ vrt_comparison () {
 
 }
 
-merge_to_main () {
+merge_to_main() {
 
   echo "Opening pull requests."
-  for repo in "${repolist[@]}" ; do
+  for repo in "${repolist[@]}"; do
     open_url "${remote_url}/${repo}/compare/main...develop"
-  done;
+  done
 }
 
-create_tags () {
+create_tags() {
 
-  for repo in "${repolist[@]}" ; do
+  for repo in "${repolist[@]}"; do
     echo "Creating tag for $repo"
 
     echo "cd-ing to the $repo repo"
@@ -355,35 +353,35 @@ create_tags () {
     echo "$url"
 
     open_url "${url}"
-  done;
+  done
 }
 
-stage_deploy () {
+stage_deploy() {
   echo "Preparing stage deployments."
   echo "Step one, refresh databases from production."
-  for repo in "${repolist[@]}" ; do
+  for repo in "${repolist[@]}"; do
     # Match repo to other names.
-    jenkins_name=$(jq -r '."'"$repo"'".jenkins_name' < ./repo-lookup.json)
-    jenkins_other_name=$(jq -r '."'"$repo"'".jenkins_other_name' < ./repo-lookup.json)
+    jenkins_name=$(jq -r '."'"$repo"'".jenkins_name' <./repo-lookup.json)
+    jenkins_other_name=$(jq -r '."'"$repo"'".jenkins_other_name' <./repo-lookup.json)
 
     echo "Opening jenkins test deploy link for $repo."
     open_url "${jenkins_url}/view/${jenkins_name}/job/${jenkins_other_name}-testdeploy/build"
-  done;
+  done
 
   echo "All done"
 }
 
-deploy_communications () {
+deploy_communications() {
   echo "Check https://docs.google.com/spreadsheets/d/1db2o3SG52uPG0SlbNuj9YyIvnqSPmCND9wQaaaC0i1Y/edit#gid=0 for communication steps"
 }
 
-prod_deploy () {
+prod_deploy() {
   echo "Preparing prod deployments."
-  for repo in "${repolist[@]}" ; do
+  for repo in "${repolist[@]}"; do
     # Match repo to other names.
-    prod_url=$(jq -r '."'"$repo"'".prod_url' < ./repo-lookup.json)
-    jenkins_name=$(jq -r '."'"$repo"'".jenkins_name' < ./repo-lookup.json)
-    jenkins_other_name=$(jq -r '."'"$repo"'".jenkins_other_name' < ./repo-lookup.json)
+    prod_url=$(jq -r '."'"$repo"'".prod_url' <./repo-lookup.json)
+    jenkins_name=$(jq -r '."'"$repo"'".jenkins_name' <./repo-lookup.json)
+    jenkins_other_name=$(jq -r '."'"$repo"'".jenkins_other_name' <./repo-lookup.json)
 
     echo "Running pre-deploy VRT for reference."
     run_vrt "$repo" reference prod
@@ -407,6 +405,6 @@ prod_deploy () {
     echo "Opening VRT reports"
     vrt_report "$repo"
 
-  done;
+  done
   echo "All done"
 }

--- a/common.sh
+++ b/common.sh
@@ -2,7 +2,10 @@
 
 # Functions that can be used by other updating scripts.
 
-# set -e
+# TODO
+# Adapt 'open' and 'copy' commands for macOS and windows too.
+
+set -eux
 
 requires () {
     if ! command -v "$1" &>/dev/null; then

--- a/common.sh
+++ b/common.sh
@@ -5,7 +5,7 @@
 # TODO
 # Adapt 'open' and 'copy' commands for macOS and windows too.
 
-set -eux
+set -eu
 
 requires() {
   if ! command -v "$1" &>/dev/null; then

--- a/common.sh
+++ b/common.sh
@@ -309,7 +309,7 @@ vrt_comparison() {
       echo "Kicking off jenkins vrt job for $repo."
       curl -X POST --user ${JENKINS_ID}:${JENKINS_TOKEN} "${jenkins_url}/view/VRT/job/vrt-anonymous/buildWithParameters?delay=0sec&REFERENCE_URI=${prod_url}&TEST_URI=${stage_url}&SITE_REPOSITORY=git@github.com:UN-OCHA/${repo}.git"
 
-      last_build_url=$(curl -X POST --user ${JENKINS_ID}:${JENKINS_TOKEN} "${jenkins_url}/view/VRT/job/vrt-anonymous/api/json" | jq ".lastBuild.url" | tr '"' '')
+      last_build_url=$(curl -X POST --user ${JENKINS_ID}:${JENKINS_TOKEN} "${jenkins_url}/view/VRT/job/vrt-anonymous/api/json" | jq ".lastBuild.url" | tr -d '"')
       results+=("${last_build_url}artifact/data/anon/html_report/index.html")
     done
   fi

--- a/common.sh
+++ b/common.sh
@@ -309,10 +309,9 @@ vrt_comparison() {
       echo "Kicking off jenkins vrt job for $repo."
       curl -X POST --user ${JENKINS_ID}:${JENKINS_TOKEN} "${jenkins_url}/view/VRT/job/vrt-anonymous/buildWithParameters?delay=0sec&REFERENCE_URI=${prod_url}&TEST_URI=${dev_url}&SITE_REPOSITORY=git@github.com:UN-OCHA/${repo}.git"
 
-      # Will return ""https://jenkins.aws.ahconu.org/job/vrt-anonymous/<last-build-number>/"
+      # Will return ""https://jenkins.aws.ahconu.org/job/vrt-anonymous/<last-build-number>/artifact/data/anon/html_report/index.html"
       last_build_url=$(curl -X POST --user ${JENKINS_ID}:${JENKINS_TOKEN} "${jenkins_url}/view/VRT/job/vrt-anonymous/api/json" | jq ".lastBuild.url" | tr -d '"')
       results+=("${last_build_url}artifact/data/anon/html_report/index.html")
-"https://jenkins.aws.ahconu.org/job/vrt-anonymous/50/artifact/data/anon/html_report/index.html"
     done
   fi
 

--- a/common.sh
+++ b/common.sh
@@ -303,14 +303,16 @@ vrt_comparison() {
       # Match repo to other names.
       prod_url=$(jq -r '."'"$repo"'".prod_url' <./repo-lookup.json)
       prod_url="https://$prod_url"
-      stage_url=$(jq -r '."'"$repo"'".stage_url' <./repo-lookup.json)
-      stage_url="https://$BASIC_AUTH_CREDENTIALS@$stage_url"
+      dev_url=$(jq -r '."'"$repo"'".dev_url' <./repo-lookup.json)
+      dev_url="https://$BASIC_AUTH_CREDENTIALS@$dev_url"
 
       echo "Kicking off jenkins vrt job for $repo."
-      curl -X POST --user ${JENKINS_ID}:${JENKINS_TOKEN} "${jenkins_url}/view/VRT/job/vrt-anonymous/buildWithParameters?delay=0sec&REFERENCE_URI=${prod_url}&TEST_URI=${stage_url}&SITE_REPOSITORY=git@github.com:UN-OCHA/${repo}.git"
+      curl -X POST --user ${JENKINS_ID}:${JENKINS_TOKEN} "${jenkins_url}/view/VRT/job/vrt-anonymous/buildWithParameters?delay=0sec&REFERENCE_URI=${prod_url}&TEST_URI=${dev_url}&SITE_REPOSITORY=git@github.com:UN-OCHA/${repo}.git"
 
+      # Will return ""https://jenkins.aws.ahconu.org/job/vrt-anonymous/<last-build-number>/"
       last_build_url=$(curl -X POST --user ${JENKINS_ID}:${JENKINS_TOKEN} "${jenkins_url}/view/VRT/job/vrt-anonymous/api/json" | jq ".lastBuild.url" | tr -d '"')
       results+=("${last_build_url}artifact/data/anon/html_report/index.html")
+"https://jenkins.aws.ahconu.org/job/vrt-anonymous/50/artifact/data/anon/html_report/index.html"
     done
   fi
 

--- a/common_changes.sh
+++ b/common_changes.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Steps through multiple repos making similar changes.
+
+. ./common.sh
+
+###################
+
+# Start here.
+echo "Before starting, check BASEDIR is set in .env and the repos listed above"
+echo "are appropriate. If necessary, alter them in repolist.txt."
+wait_to_continue
+
+# Get ticket number.
+echo "Enter ticket number:"
+read -r ticket_number
+
+create_pr "$ticket_number"

--- a/deployment_steps.sh
+++ b/deployment_steps.sh
@@ -1,25 +1,20 @@
 #!/bin/bash
 
-# Steps through the update process for drupal core or contrib modules.
+# Steps through the deployment process.
 
-# There are 5 stages, each with its own steps. This script tries to provide
+# There are 7 stages, each with its own steps. This script tries to provide
 # helpers for each of those stages, though some of those helpers are little
 # more than links.
 # The stages:
-# 1. create PR
-# 2. vrt comparison of prod and dev
-# 3. Send communications, update Jira tickets
-# 4. merge to main
-# 5. create tags
-# 6. stage deploy
-# 7. Send more communications
-# 8. prod deploy
+# 1. vrt comparison of prod and dev
+# 2. Send communications, update Jira tickets
+# 3. merge to main
+# 4. create tags
+# 5. stage deploy
+# 6. Send more communications
+# 7. prod deploy
 
 . ./common.sh
-
-# TODO
-# Add open and copy for macOS, and windows.
-# Include VRT - at least open some pages to test it.
 
 ###################
 
@@ -28,20 +23,12 @@ echo "Before starting, check BASEDIR is set in .env and the repos listed above"
 echo "are appropriate. If necessary, alter them in repolist.txt."
 wait_to_continue
 
-# Get ticket number.
-echo "Enter ticket number:"
-read -r ticket_number
-
 # Choose stage.
 # Get type of update.
 echo "Choose stage of updates"
-options=("create PR" "send dev communications" "vrt comparison of prod and dev"  "merge to main" "create tags" "stage_deploy" "send deploy communications" "prod deploy")
+options=("send dev communications" "vrt comparison of prod and dev"  "merge to main" "create tags" "stage_deploy" "send deploy communications" "prod deploy")
 select stage in "${options[@]}"; do
   case $stage in
-    "create PR")
-      create_pr "$ticket_number"
-
-      break;;
     "send dev communications")
       dev_communications
 
@@ -73,4 +60,3 @@ select stage in "${options[@]}"; do
     *) echo "invalid option ${REPLY}. Please choose a number."
   esac
 done
-

--- a/deployment_steps.sh
+++ b/deployment_steps.sh
@@ -26,37 +26,44 @@ wait_to_continue
 # Choose stage.
 # Get type of update.
 echo "Choose stage of updates"
-options=("send dev communications" "vrt comparison of prod and dev"  "merge to main" "create tags" "stage_deploy" "send deploy communications" "prod deploy")
+options=("send dev communications" "vrt comparison of prod and dev" "merge to main" "create tags" "stage_deploy" "send deploy communications" "prod deploy")
 select stage in "${options[@]}"; do
   case $stage in
-    "send dev communications")
-      dev_communications
+  "send dev communications")
+    dev_communications
 
-      break;;
-    "vrt comparison of prod and dev")
-      vrt_comparison
+    break
+    ;;
+  "vrt comparison of prod and dev")
+    vrt_comparison
 
-      break;;
-    "merge to main")
-      merge_to_main
+    break
+    ;;
+  "merge to main")
+    merge_to_main
 
-      break;;
-    "create tags")
-      create_tags
+    break
+    ;;
+  "create tags")
+    create_tags
 
-      break;;
-    "stage_deploy")
-      stage_deploy
+    break
+    ;;
+  "stage_deploy")
+    stage_deploy
 
-      break;;
-    "send deploy communications")
-      deploy_communications
+    break
+    ;;
+  "send deploy communications")
+    deploy_communications
 
-      break;;
-    "prod deploy")
-      prod_deploy
+    break
+    ;;
+  "prod deploy")
+    prod_deploy
 
-      break;;
-    *) echo "invalid option ${REPLY}. Please choose a number."
+    break
+    ;;
+  *) echo "invalid option ${REPLY}. Please choose a number." ;;
   esac
 done

--- a/module_audit.sh
+++ b/module_audit.sh
@@ -21,7 +21,7 @@ wait_to_continue
 # Prepare header.
 printf -v date '%(%Y-%m-%d)T' -1
 header_row="Last updated: ${date}. ; Maintenance status ; Security coverage ; Count "
-for repo in "${repolist[@]}" ; do
+for repo in "${repolist[@]}"; do
   header_row="$header_row ; $repo"
 done
 options=("full" "outdated")
@@ -36,24 +36,24 @@ for type in "${options[@]}"; do
     fields="1,2,3,4"
     base_output_file="outdatedlist.csv"
   fi
-  vendors=( "drupal" "unocha" )
-  for vendor in "${vendors[@]}" ; do
+  vendors=("drupal" "unocha")
+  for vendor in "${vendors[@]}"; do
     spacer=""
     packages="${vendor}/*"
     output_file="data/${vendor}-${base_output_file}"
-    echo "$header_row" > "$output_file"
+    echo "$header_row" >"$output_file"
 
-    for repo in "${repolist[@]}" ; do
+    for repo in "${repolist[@]}"; do
       spacer+=";"
-      for module_details in $(composer show --locked --direct $option -d "${full_path}/${repo}" "${packages}" \
-        | tr -s " " | cut -f $fields -d ' ' --output-delimiter=";" | cut -d '/' -f 2 ); do
-        module_name=$(echo "$module_details" | cut -d ';' -f 1 )
-        module_version=$(echo "$module_details" | cut -d ';' -f 2 )
+      for module_details in $(composer show --locked --direct $option -d "${full_path}/${repo}" "${packages}" |
+        tr -s " " | cut -f $fields -d ' ' --output-delimiter=";" | cut -d '/' -f 2); do
+        module_name=$(echo "$module_details" | cut -d ';' -f 1)
+        module_version=$(echo "$module_details" | cut -d ';' -f 2)
         # Extra information.
         extra=""
         # Check if this module is the same as on main
         cd "${full_path}/${repo}" || exit
-        git diff -w -U1 main composer.lock | tr '\n' ' ' > main.diff
+        git diff -w -U1 main composer.lock | tr '\n' ' ' >main.diff
         if grep "drupal/${module_name}\",.*-.*\"version" main.diff; then
           extra="$extra - Not as Main"
         fi
@@ -71,7 +71,7 @@ for type in "${options[@]}"; do
           # Already in the list - add repo to line.
           awk -v pattern="^${module_name};" -v repo="$module_version $extra" \
             '{if ($0 ~ pattern) print $0 repo; else print $0 }' "$output_file" \
-            > tmpfile.txt && mv tmpfile.txt "$output_file"
+            >tmpfile.txt && mv tmpfile.txt "$output_file"
         else
           # Not yet in the list, add another line and relevant information.
           count_formula="=COUNTA(INDIRECT(ADDRESS(ROW(),COLUMN()+1,4)):INDIRECT(ADDRESS(ROW(),COLUMN()+16,4)))"
@@ -84,23 +84,22 @@ for type in "${options[@]}"; do
               covered="No release history"
             else
               maintenance=$(echo "$release_history" | xmllint --xpath "//project/terms/term[name='Maintenance status']/value/text()" -)
-              covered=$(echo "$release_history" | xmllint --xpath "(//project/releases/release/security/text())[1]" - | sed "s/overed/overed#/" | cut -d'#' -f1 )
+              covered=$(echo "$release_history" | xmllint --xpath "(//project/releases/release/security/text())[1]" - | sed "s/overed/overed#/" | cut -d'#' -f1)
             fi
-            echo "${module_name};${maintenance:=No maintenance status specified};${covered:=No security coverage specified};${count_formula}${spacer}$module_version $extra" >> "$output_file"
+            echo "${module_name};${maintenance:=No maintenance status specified};${covered:=No security coverage specified};${count_formula}${spacer}$module_version $extra" >>"$output_file"
           else
-            echo "${module_name};;;${count_formula}${spacer}$module_version $extra" >> "$output_file"
+            echo "${module_name};;;${count_formula}${spacer}$module_version $extra" >>"$output_file"
           fi
         fi
       done
       # Add a trailing semi-colon to each line.
-      awk '{print $0 ";"}' "$output_file" > tmpfile.txt && mv tmpfile.txt "$output_file"
-    done;
+      awk '{print $0 ";"}' "$output_file" >tmpfile.txt && mv tmpfile.txt "$output_file"
+    done
 
-    LC_COLLATE=C sort "$output_file" > tmpfile.txt && mv tmpfile.txt "$output_file"
+    LC_COLLATE=C sort "$output_file" >tmpfile.txt && mv tmpfile.txt "$output_file"
     echo "Results ready in $output_file."
-  done;
-done;
-
+  done
+done
 
 spreadsheet_url="https://docs.google.com/spreadsheets/d/1iMSJE5Lhk86m0lBWLE1R64QFGxZhFUfmconmmyu3XAU/edit"
 copy_to_clipboard "${spreadsheet_url}"

--- a/repo-lookup.json
+++ b/repo-lookup.json
@@ -2,6 +2,7 @@
   "cerf8": {
     "elk_name": "cerf",
     "stack_name": "cerf-stack",
+    "dev_url": "dev.cerf-un-org.ahconu.org",
     "stage_url": "stage.cerf-un-org.ahconu.org",
     "prod_url": "cerf.un.org",
     "jenkins_name": "CERF",
@@ -10,6 +11,7 @@
   "common-design-site": {
     "elk_name": "commondesign",
     "stack_name": "common-design-stack",
+    "dev_url": "dev.commondesign-unocha-org.ahconu.org",
     "stage_url": "stage.commondesign-unocha-org.ahconu.org",
     "prod_url": "web.brand.unocha.org",
     "jenkins_name": "Common Design",
@@ -18,6 +20,7 @@
   "drupal-starterkit": {
     "elk_name": "n/a",
     "stack_name": "n/a",
+    "dev_url": "n/a",
     "stage_url": "n/a",
     "prod_url": "n/a",
     "jenkins_name": "n/a",
@@ -26,6 +29,7 @@
   "gms-site": {
     "elk_name": "gms",
     "stack_name": "gms-stack",
+    "dev_url": "dev.gms-unocha-org.ahconu.org",
     "stage_url": "stage.gms-unocha-org.ahconu.org",
     "prod_url": "gms.unocha.org",
     "jenkins_name": "GMS",
@@ -34,6 +38,7 @@
   "iasc8": {
     "elk_name": "iasc",
     "stack_name": "iasc-stack",
+    "dev_url": "dev.interagencystandingcommittee-org.ahconu.org",
     "stage_url": "stage.interagencystandingcommittee-org.ahconu.org",
     "prod_url": "interagencystandingcommittee.org",
     "jenkins_name": "IASC",
@@ -42,6 +47,7 @@
   "odsg8-site": {
     "elk_name": "odsg",
     "stack_name": "odsg-stack",
+    "dev_url": "dev.odsg-unocha-org.ahconu.org",
     "stage_url": "stage.odsg-unocha-org.ahconu.org",
     "prod_url": "odsg.unocha.org",
     "jenkins_name": "ODSG",
@@ -50,6 +56,7 @@
   "response-site": {
     "elk_name": "response",
     "stack_name": "response-stack",
+    "dev_url": "dev.response-reliefweb-int.ahconu.org",
     "stage_url": "stage.response-reliefweb-int.ahconu.org",
     "prod_url": "response.reliefweb.int",
     "jenkins_name": "Response",
@@ -58,6 +65,7 @@
   "rwint9-site": {
     "elk_name": "rwint",
     "stack_name": "rwint-stack",
+    "dev_url": "dev.reliefweb-int.ahconu.org",
     "stage_url": "stage.reliefweb-int.ahconu.org",
     "prod_url": "reliefweb.int",
     "jenkins_name": "ReliefWeb",
@@ -66,6 +74,7 @@
   "slt8-site": {
     "elk_name": "slt",
     "stack_name": "slt-stack",
+    "dev_url": "dev.savinglivestogether-unocha-org.ahconu.org",
     "stage_url": "stage.savinglivestogether-unocha-org.ahconu.org",
     "prod_url": "savinglivestogether.unocha.org",
     "jenkins_name": "SLT",
@@ -74,6 +83,7 @@
   "sesame-site": {
     "elk_name": "sesame",
     "stack_name": "sesame-stack",
+    "dev_url": "dev.auth-unocha-org.ahconu.org",
     "stage_url": "stage.auth-unocha-org.ahconu.org",
     "prod_url": "auth.ahconu.org",
     "jenkins_name": "Sesame",
@@ -82,6 +92,7 @@
   "unocha-site": {
     "elk_name": "unocha",
     "stack_name": "unocha-stack",
+    "dev_url": "dev.unocha-org.ahconu.org",
     "stage_url": "stage.unocha-org.ahconu.org",
     "prod_url": "unocha.org",
     "jenkins_name": "UN-OCHA",
@@ -90,6 +101,7 @@
   "whd-2023-site": {
     "elk_name": "whd",
     "stack_name": "whd-stack",
+    "dev_url": "dev.worldhumanitarianday-org.ahconu.org",
     "stage_url": "stage.worldhumanitarianday-org.ahconu.org",
     "prod_url": "worldhumanitarianday.org",
     "jenkins_name": "WHD",

--- a/repolist.txt
+++ b/repolist.txt
@@ -1,19 +1,10 @@
-# Use '#' symbol to comment out lines.
-# When adding repos here, also update alternative names in `prod_deploy()`.
-
-# The stages:
-# 1. create PR
-# 2. send dev communications
-# 3. vrt comparison of prod and stage
-# 4. merge to main
-# 5. create tags
-# 6. stage deploy
-# 6. send deploy communications
-# 7. prod deploy
+# Use '#' symbol to comment out repos.
+# When adding repos here, also add to `repo-lookup.txt`.
 
 cerf8
 common-design-site
 drupal-starterkit
+dsr-site
 gms-site
 iasc8
 odsg8-site
@@ -22,32 +13,3 @@ rwint9-site
 slt8-site
 sesame-site
 unocha-site
-
-
-## Now static
-# indicatorregistry8-site
-# pocam8-site
-# whd-2023-site
-
-## Decommissioned
-# assessmentregistry8-site
-# docstore-site
-# hrinfo-site
-# numbers-site
-
-# URLs for reference:
-# https://web.brand.unocha.org/
-# https://demo.commondesign-unocha-org.ahconu.org/
-# https://cerf.un.org/
-# https://dev.cerf-un-org.ahconu.org/
-# https://gms.unocha.org/
-# https://dev.gms-unocha-org.ahconu.org/
-# https://interagencystandingcommittee.org/
-# https://dev.interagencystandingcommittee-org.ahconu.org/
-# https://odsg.unocha.org/
-# https://dev.odsg-unocha-org.ahconu.org/
-# https://reliefweb.int/
-# https://dev.reliefweb-int.ahconu.org
-# https://savinglivestogether.unocha.org/welcome?destination=/saving-lives-together
-# http://dev.savinglivestogether-unocha-org.ahconu.org/welcome?destination=/saving-lives-together
-# auth.ahconu.org

--- a/reset_branches.sh
+++ b/reset_branches.sh
@@ -7,7 +7,7 @@ source ./common.sh
 
 wait_to_continue
 
-for repo in "${repolist[@]}" ; do
+for repo in "${repolist[@]}"; do
 
   echo "- - -"
   echo " --- "
@@ -36,4 +36,4 @@ for repo in "${repolist[@]}" ; do
 
   # wait_to_continue
 
-done;
+done

--- a/reset_branches.sh
+++ b/reset_branches.sh
@@ -9,8 +9,6 @@ wait_to_continue
 
 for repo in "${repolist[@]}" ; do
 
-  docker_image=$(awk '/FROM/ {print $2; exit 1}' "${full_path}/${repo}/docker/Dockerfile")
-
   echo "- - -"
   echo " --- "
   echo "- - -"


### PR DESCRIPTION
Refs: updates

@left23 this is intended to remove some of the confusion in the organization of these scripts since the periodic updates took over.

`drupal_updates.sh` is gone, replaced by `common_changes.sh` and `deployment_steps.sh`. The latter should be simplified when I work out running the deployment VRT tests through Jenkins (https://github.com/UN-OCHA/tools-jenkins-jobs/pull/72).

I've also tried to update the README - please do call out / rewrite the bits that remain unclear!